### PR TITLE
BAU: fix dockerfile and add build step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Clone the repository
 From the top-level directory enter the command to install pip and the dependencies of the project
 
     python3 -m pip install --upgrade pip && pip install -r requirements.txt
+    python3 ./build.py
 
 ## How to use
 Enter the virtual environment as described above, then:

--- a/dockerfile
+++ b/dockerfile
@@ -1,12 +1,10 @@
-FROM alpine:latest
+FROM python:3.10-slim-bullseye
 
-RUN apk update
-RUN apk add py-pip
-RUN apk add --no-cache python3-dev
 RUN pip install --upgrade pip
 
 WORKDIR /app
 COPY . /app
 RUN pip --no-cache-dir install --ignore-installed distlib -r requirements.txt
+RUN python3 build.py
 
 CMD ["flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
When building the previous Dockerfile on my M1 Mac I got the following error:
```
#13 40.51       creating build/temp.linux-aarch64-cpython-39/c
#13 40.51       gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -g -fno-semantic-interposition -g -fno-semantic-interposition -g -fno-semantic-interposition -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.9 -c c/_cffi_backend.c -o build/temp.linux-aarch64-cpython-39/c/_cffi_backend.o
#13 40.51       error: command 'gcc' failed: No such file or directory
#13 40.51       [end of output]
#13 40.51   
#13 40.51   note: This error originates from a subprocess, and is likely not a problem with pip.
#13 40.52 error: legacy-install-failure
#13 40.52 
#13 40.52 × Encountered error while trying to install package.
#13 40.52 ╰─> cffi
#13 40.52 
```
Switching to python 3.10 slim-bullseye fixes the issue

- BAU: Fix dockerfile
- add build step to README
