### PR TITLE
BAU:  Manual Workflow Trigger to Stress Test Frontend 

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,30 @@
+# This is a basic workflow that is manually triggered
+
+name: Manual workflow
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      name:
+        # Friendly description to be shown in the UI instead of 'name'
+        description: 'Person to greet'
+        # Default value if no value is explicitly provided
+        default: 'World'
+        # Input has to be provided for the workflow to run
+        required: true
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "greet"
+  greet:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Runs a single command using the runners shell
+    - name: Send greeting
+      run: echo "Hello ${{ github.event.inputs.name }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -3,15 +3,15 @@ on:
   workflow_call:
     inputs:
      users:
-        required: false
+        required: true
         default: 1
         type: string
      spawn-rate:
-        required: false
+        required: true
         default: 1
         type: string
      run-time:
-        required: false
+        required: true
         default: 10s
         type: string
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,4 +1,4 @@
-name: Manual Workflow Trigger to Perform Stress Test on Discovery Frontend
+name: Manual Stress Test on Frontend
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,30 +1,36 @@
 # This is a basic workflow that is manually triggered
 
-name: Manual workflow
-
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
+name: Manual Trigger to Stress Test Application
 on:
   workflow_dispatch:
-    # Inputs the workflow accepts.
-    inputs:
-      name:
-        # Friendly description to be shown in the UI instead of 'name'
-        description: 'Person to greet'
-        # Default value if no value is explicitly provided
-        default: 'World'
-        # Input has to be provided for the workflow to run
-        required: true
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+  push:
+      branches:
+      - main
 jobs:
-  # This workflow contains a single job called "greet"
-  greet:
-    # The type of runner that the job will run on
+  run_performance_tests:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    environment: test
     steps:
-    # Runs a single command using the runners shell
-    - name: Send greeting
-      run: echo "Hello ${{ github.event.inputs.name }}"
+      - name: checkout code
+        uses: actions/checkout@main
+        with:
+          repository: communitiesuk/funding-service-design-performance-tests
+          path: ./funding-service-design-performance-tests
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10.1
+      - name: create python env
+        run: python -m venv .venv
+      - name: install dependencies
+        run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
+
+      - name: Run performance tests
+        run: ls && python -m pip install locust && python -m locust
+        working-directory: ./funding-service-design-performance-tests
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: performance-test-report
+          path: ./funding-service-design-performance-tests/locust_html_report.html
+          retention-days: 5

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,8 +1,6 @@
-# This is a basic workflow that is manually triggered
-
-name: Manual Trigger to Stress Test Application
+name: Manual Workflow Trigger to Perform Stress Test on Discovery Frontend
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
      users:
         required: false
@@ -16,7 +14,8 @@ on:
         required: false
         default: 10s
         type: string
-
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 env:
   users: 1
   spawn-rate: 1

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -3,9 +3,25 @@
 name: Manual Trigger to Stress Test Application
 on:
   workflow_dispatch:
-  push:
-      branches:
-      - main
+    inputs:
+     users:
+        required: false
+        default: 1
+        type: string
+     spawn-rate:
+        required: false
+        default: 1
+        type: string
+     run-time:
+        required: false
+        default: 10s
+        type: string
+
+env:
+  users: 1
+  spawn-rate: 1
+  run-time: 10s
+
 jobs:
   run_performance_tests:
     runs-on: ubuntu-latest
@@ -26,7 +42,7 @@ jobs:
         run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r ./funding-service-design-performance-tests/requirements.txt
 
       - name: Run performance tests
-        run: ls && python -m pip install locust && python -m locust
+        run: ls && python -m pip install locust && python -m locust --users ${{inputs.users}} --spawn-rate ${{inputs.spawn-rate}} --run-time ${{inputs.run-time}}
         working-directory: ./funding-service-design-performance-tests
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
As per test plan:
https://digital.dclg.gov.uk/confluence/display/FS/Community+Ownership+Fund+%28COF%29+Round+2+Performance+Test+Plan

I have added a new workflow that will appear in GitHub Actions.  The new workflow is manually triggered where it will run the performance tests across all the apis with configurable environment variables that can be used to adjust the locust configs for the performance tests, so that we can for example, run the tests with 10+ users. 

This will be handy when we need to stress test the entire application as per the diagram below:

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/36962596/173798079-28b805f3-f8c0-46f9-b9f7-7e604f6ea726.png">
