### PR TITLE
FSB-657: make development config overridable from ENV

### DIFF
--- a/config/environments/development.py
+++ b/config/environments/development.py
@@ -1,3 +1,5 @@
+import os
+
 from config.environments.default import DefaultConfig
 from fsd_utils import configclass
 
@@ -5,5 +7,5 @@ from fsd_utils import configclass
 @configclass
 class DevelopmentConfig(DefaultConfig):
 
-    USE_LOCAL_DATA = True
-    FUND_STORE_API_HOST = "fund_store"
+    USE_LOCAL_DATA = os.environ.get("USE_LOCAL_DATA", True)
+    FUND_STORE_API_HOST = os.environ.get("FUND_STORE_API_HOST", "fund_store")


### PR DESCRIPTION
make development config overridable from ENV to make it more usable in docker compose context.