### PR TITLE
BAU: GitHub Action tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,7 @@ jobs:
     needs: security
     runs-on: ubuntu-latest
     environment: test
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.10.1
-      - name: create python env
-        run: python -m venv .venv
-      - name: install dependencies
-        run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
       - name: build static assets
         run: python build.py
       - name: Deploy to Gov PaaS
@@ -104,10 +100,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.10.1
-      - name: create python env
-        run: python -m venv .venv
-      - name: install dependencies
-        run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
       - name: build static assets
         run: python build.py
       - name: Deploy to Gov PaaS


### PR DESCRIPTION
PaaS installs the dependencies so there is no need to install them on Github Actions first.
Also only deploy main branch to test, as per other apps.