### PR TITLE
BAU: bump dependencies to fix build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ email-validator==1.2.1
 execnet==1.9.0
 Faker==13.3.1
 filelock==3.4.2
-Flask==2.0.2
+Flask==2.1.2
 Flask-Compress==1.10.1
 flask-restx==0.5.1
 Flask-SeaSurf==0.3.1
@@ -83,7 +83,7 @@ pytest-xdist==2.5.0
 python-dateutil==2.8.2
 python-dotenv==0.20.0
 python-slugify==6.0.1
-pytz==2021.3
+pytz==2022.1
 PyYAML==6.0
 reportportal-client==5.1.0
 requests==2.27.1


### PR DESCRIPTION
Build was failing due to newer requirements being required from the utils repo e.g.

```
#0 15.46 The conflict is caused by:
#0 15.46     The user requested Flask==2.0.2
#0 15.46     connexion 2.13.1 depends on flask<3 and >=1.0.4
#0 15.46     flask-compress 1.10.1 depends on flask
#0 15.46     flask-restx 0.5.1 depends on Flask!=2.0.0 and >=0.8
#0 15.46     flask-seasurf 0.3.1 depends on Flask
#0 15.46     flask-wtf 1.0.0 depends on Flask
#0 15.46     pytest-flask 1.2.0 depends on Flask
#0 15.46     funding-service-design-utils 0.0.8 depends on Flask<3.0.0 and >=2.1.1
```
This bumps the required dependencies to fix the build
